### PR TITLE
move user-loader to a separate file and remove global middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm i -S @accounts/rest-express
 import express from 'express';
 import bodyParser from 'body-parser';
 import { AccountsServer } from '@accounts/server';
-import accountsExpress from '@accounts/rest-express';
+import accountsExpress, { userLoader } from '@accounts/rest-express';
 
 const app = express();
 app.use(bodyParser.json());
@@ -24,4 +24,16 @@ app.use(bodyParser.json());
 const accountsServer = new AccountsServer({ ...options });
 const accountsExpressOptions = { ...options };
 app.use(accountsExpress(accountsServer, accountsExpressOptions));
+
+// To bind all routes
+app.use(userLoader(accountsServer));
+
+// to bind a specific route
+app.get('/protected', userLoader(accountsServer), (req, res) => {
+  if (!req.user) {
+    res.status(401).send();
+    return;
+  }
+  res.send(req.user))
+}
 ```

--- a/packages/express/__tests__/express-middleware.ts
+++ b/packages/express/__tests__/express-middleware.ts
@@ -1,11 +1,9 @@
 import accountsExpress from '../src';
-import { userLoader } from '../src/express-middleware';
 import * as express from 'express';
 
 jest.mock('express', () => {
   const mockRouter = {
     post: jest.fn(),
-    use: jest.fn(),
     get: jest.fn(),
   };
   return {
@@ -27,7 +25,6 @@ describe('express middleware', () => {
       } as any,
       { path: 'test' }
     );
-    expect(router.use).toHaveBeenCalledTimes(1); // Assigning user provider
     expect(router.post.mock.calls[0][0]).toBe('test/impersonate');
     expect(router.post.mock.calls[1][0]).toBe('test/user');
     expect(router.post.mock.calls[2][0]).toBe('test/refreshTokens');
@@ -44,7 +41,6 @@ describe('express middleware', () => {
       } as any,
       { path: 'test' }
     );
-    expect(router.use).toHaveBeenCalledTimes(1); // Assigning user provider
     expect(router.post.mock.calls[0][0]).toBe('test/impersonate');
     expect(router.post.mock.calls[1][0]).toBe('test/user');
     expect(router.post.mock.calls[2][0]).toBe('test/refreshTokens');
@@ -70,71 +66,11 @@ describe('express middleware', () => {
       } as any,
       { path: 'test' }
     );
-    expect(router.use).toHaveBeenCalledTimes(1); // Assigning user provider
     expect(router.post.mock.calls[0][0]).toBe('test/impersonate');
     expect(router.post.mock.calls[1][0]).toBe('test/user');
     expect(router.post.mock.calls[2][0]).toBe('test/refreshTokens');
     expect(router.post.mock.calls[3][0]).toBe('test/logout');
     expect(router.post.mock.calls[4][0]).toBe('test/:service/authenticate');
     expect(router.get.mock.calls[0][0]).toBe('test/oauth/:provider/callback');
-  });
-});
-
-const user = { id: '1' };
-const accountsServer = {
-  resumeSession: jest.fn(() => user),
-};
-describe('userLoader', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('does noting when request has no accessToken', async () => {
-    const provider = userLoader(accountsServer as any);
-    const req = {};
-    const res = {};
-    const next = jest.fn();
-    await provider(req, res, next);
-
-    expect(accountsServer.resumeSession).not.toHaveBeenCalled();
-    expect(req).toEqual({});
-    expect(res).toEqual({});
-    expect(next).toHaveBeenCalledTimes(1);
-  });
-
-  it('load user to req object when access token is present on the headers', async () => {
-    const provider = userLoader(accountsServer as any);
-    const req = {
-      headers: {
-        'accounts-access-token': 'token',
-      },
-    };
-    const reqCopy = { ...req };
-    const res = {};
-    const next = jest.fn();
-    await provider(req, res, next);
-
-    expect(accountsServer.resumeSession).toHaveBeenCalledWith('token');
-    expect(req).toEqual({ ...reqCopy, user, userId: user.id });
-    expect(res).toEqual({});
-    expect(next).toHaveBeenCalledTimes(1);
-  });
-
-  it('load user to req object when access token is present on the body', async () => {
-    const provider = userLoader(accountsServer as any);
-    const req = {
-      body: {
-        accessToken: 'token',
-      },
-    };
-    const reqCopy = { ...req };
-    const res = {};
-    const next = jest.fn();
-    await provider(req, res, next);
-
-    expect(accountsServer.resumeSession).toHaveBeenCalledWith('token');
-    expect(req).toEqual({ ...reqCopy, user, userId: user.id });
-    expect(res).toEqual({});
-    expect(next).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/express/__tests__/user-loader.ts
+++ b/packages/express/__tests__/user-loader.ts
@@ -1,0 +1,61 @@
+import accountsExpress from '../src';
+import { userLoader } from '../src/user-loader';
+
+const user = { id: '1' };
+const accountsServer = {
+  resumeSession: jest.fn(() => user),
+};
+describe('userLoader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does noting when request has no accessToken', async () => {
+    const provider = userLoader(accountsServer as any);
+    const req = {};
+    const res = {};
+    const next = jest.fn();
+    await provider(req, res, next);
+
+    expect(accountsServer.resumeSession).not.toHaveBeenCalled();
+    expect(req).toEqual({});
+    expect(res).toEqual({});
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('load user to req object when access token is present on the headers', async () => {
+    const provider = userLoader(accountsServer as any);
+    const req = {
+      headers: {
+        'accounts-access-token': 'token',
+      },
+    };
+    const reqCopy = { ...req };
+    const res = {};
+    const next = jest.fn();
+    await provider(req, res, next);
+
+    expect(accountsServer.resumeSession).toHaveBeenCalledWith('token');
+    expect(req).toEqual({ ...reqCopy, user, userId: user.id });
+    expect(res).toEqual({});
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('load user to req object when access token is present on the body', async () => {
+    const provider = userLoader(accountsServer as any);
+    const req = {
+      body: {
+        accessToken: 'token',
+      },
+    };
+    const reqCopy = { ...req };
+    const res = {};
+    const next = jest.fn();
+    await provider(req, res, next);
+
+    expect(accountsServer.resumeSession).toHaveBeenCalledWith('token');
+    expect(req).toEqual({ ...reqCopy, user, userId: user.id });
+    expect(res).toEqual({});
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/express/src/express-middleware.ts
+++ b/packages/express/src/express-middleware.ts
@@ -18,6 +18,7 @@ import { impersonate } from './endpoints/impersonate';
 import { logout } from './endpoints/logout';
 import { serviceAuthenticate } from './endpoints/service-authenticate';
 import { registerPassword } from './endpoints/password/register';
+import { userLoader } from './user-loader';
 
 export interface AccountsExpressOptions {
   path?: string;
@@ -27,35 +28,14 @@ const defaultOptions: AccountsExpressOptions = {
   path: '/accounts',
 };
 
-export const userLoader = (accountsServer: AccountsServer) => async (
-  req: express.Request,
-  res: express.Response,
-  next: any
-) => {
-  const accessToken =
-    get(req.headers, 'accounts-access-token') ||
-    get(req.body, 'accessToken', undefined);
-  if (!isEmpty(accessToken)) {
-    try {
-      const user = await accountsServer.resumeSession(accessToken);
-      (req as any).user = user;
-      (req as any).userId = user.id;
-    } catch (e) {
-      // Do nothing
-    }
-  }
-  next();
-};
-
 const accountsExpress = (
   accountsServer: AccountsServer,
   options: AccountsExpressOptions = {}
 ): express.Router => {
   options = { ...defaultOptions, ...options };
   const { path } = options;
-  const router = express.Router();
 
-  router.use(userLoader(accountsServer));
+  const router = express.Router();
 
   router.post(`${path}/impersonate`, impersonate(accountsServer));
 

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -1,4 +1,3 @@
-import middleware, { userLoader } from './express-middleware';
-
-export { userLoader };
+import middleware from './express-middleware';
+export { userLoader } from './user-loader';
 export default middleware;

--- a/packages/express/src/user-loader.ts
+++ b/packages/express/src/user-loader.ts
@@ -1,0 +1,23 @@
+import * as express from 'express';
+import { get, isEmpty } from 'lodash';
+import { AccountsServer } from '@accounts/server';
+
+export const userLoader = (accountsServer: AccountsServer) => async (
+  req: express.Request,
+  res: express.Response,
+  next: any
+) => {
+  const accessToken =
+    get(req.headers, 'accounts-access-token') ||
+    get(req.body, 'accessToken', undefined);
+  if (!isEmpty(accessToken)) {
+    try {
+      const user = await accountsServer.resumeSession(accessToken);
+      (req as any).user = user;
+      (req as any).userId = user.id;
+    } catch (e) {
+      // Do nothing
+    }
+  }
+  next();
+};


### PR DESCRIPTION
Right now we were using a user loader for all routes that does not make any sense to load the user for login route etc ..
With that change the user will have to add manually the loader to his express application